### PR TITLE
Fix artifact generation ...

### DIFF
--- a/.github/workflows/vdiffr.yaml
+++ b/.github/workflows/vdiffr.yaml
@@ -52,8 +52,8 @@ jobs:
 
       - name: Compare snapshots
         run: |
-          Rscript -e "tmp <- '${{ runner.temp }}'; testthat::test_file('${{ runner.temp }}/test-snapshots.R', stop_on_failure=TRUE)"
           Rscript -e "tmp <- '${{ runner.temp }}'; source('${{ runner.temp }}/make_artifact.R')"
+          Rscript -e "tmp <- '${{ runner.temp }}'; testthat::test_file('${{ runner.temp }}/test-snapshots.R', stop_on_failure=TRUE)"
 
       - name: Save snapshots as artifacts
         uses: actions/upload-artifact@v2


### PR DESCRIPTION

# Fix vdiffr (3)

## Description 

Make artifacts before comparing snapshots so that they can be built even if the comparison of snapshots fails.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
