### PR TITLE
FIX: Prepare and save artifacts before comparing snapshots

### DIFF
--- a/.github/workflows/vdiffr.yaml
+++ b/.github/workflows/vdiffr.yaml
@@ -50,14 +50,17 @@ jobs:
           Rscript -e "remotes::install_local('.', dependencies = FALSE, force = TRUE)"
           Rscript -e "pkg_version <- 'Release'; tmp <- '${{ runner.temp }}'; source('${{ runner.temp }}/generate-snapshots.R')"
 
-      - name: Compare snapshots
+      - name: Prepare artifacts
         run: |
           Rscript -e "tmp <- '${{ runner.temp }}'; source('${{ runner.temp }}/make_artifact.R')"
-          Rscript -e "tmp <- '${{ runner.temp }}'; testthat::test_file('${{ runner.temp }}/test-snapshots.R', stop_on_failure=TRUE)"
 
       - name: Save snapshots as artifacts
         uses: actions/upload-artifact@v2
         with:
           name: Snapshots
           path: ${{ runner.temp }}/vdiffr_artifact.zip
+
+      - name: Compare snapshots
+        run: |
+          Rscript -e "tmp <- '${{ runner.temp }}'; testthat::test_file('${{ runner.temp }}/test-snapshots.R', stop_on_failure=TRUE)"
 


### PR DESCRIPTION

# Fix vdiffr (4)

## Description 

Prepare and save artifacts before comparing snapshots otherwise artifacts are not saved if snapshot comparison fails.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
