### PR TITLE
Activate automatic check for push on all branches

### DIFF
--- a/.github/workflows/check-standard.yaml
+++ b/.github/workflows/check-standard.yaml
@@ -2,7 +2,7 @@
 # Need help debugging build failures? Start at https://github.com/r-lib/actions#where-to-find-help
 on:
   push:
-    branches: [main, master]
+#    branches: [main, master]
   pull_request:
     branches: [main, master]
 


### PR DESCRIPTION
Automatic checks were not done on branches other than main. This pull request to fix that.