### PR TITLE
Prepare release 1.0.0

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -2,13 +2,13 @@
 # CITATION file created with {cffr} R package
 # See also: https://docs.ropensci.org/cffr/
 # --------------------------------------------
- 
+
 cff-version: 1.2.0
 message: 'To cite package "CroPlotR" in publications use:'
 type: software
 title: 'CroPlotR: A Package to Analyze Crop Model Simulations Outputs with Plots and
   Statistics'
-version: 0.11.0
+version: 1.0.0
 abstract: CroplotR aims at the standardization of the process of analyzing the outputs
   of crop models using plots and statistics. Users can generate plots presented in
   dynamic mode with time on the x axis and any simulated and/or observed variable(s)

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -2,8 +2,8 @@ Type: Package
 Package: CroPlotR
 Title: A Package to Analyze Crop Model Simulations Outputs with Plots and
     Statistics
-Version: 0.11.0
-Date: 2025-10-31
+Version: 1.0.0
+Date: 2026-01-23
 Authors@R: c(
     person("Remi", "Vezy", , "remi.vezy@cirad.fr", role = c("aut", "cre"),
            comment = c(ORCID = "0000-0002-0808-1461")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,29 @@
+# CroPlotR 1.0.0 (2026-01-23)
+
+## NEW FEATURES
+
+- New plotting capabilities:
+  - Residuals can now be used as reference variables on the X-axis of scatter plots.
+  - Simulated variables can now be plotted against various reference variables.
+- Scatter plots are now displayed in a square format with identical boundaries on both axes.
+- New combinations of plotting options are now supported, allowing more flexible and customizable graphics.
+
+## BUG FIXES
+
+- Support for **ggplot2 >= 4.0.0**.
+- Minor bug fixes and stability improvements resulting from the major refactoring of the code base.
+
+## DOCUMENTATION & TESTS
+
+- Documentation has been significantly improved and expanded.
+- Many new unit tests have been added to improve robustness and reliability.
+
+## INTERNAL CHANGES
+
+- Major refactoring of the internal code base to improve clarity, maintainability, and long-term evolution.
+- Reduced dependencies on external packages, simplifying installation and maintenance.
+
+
 # CroPlotR v0.11.0 (2025-31-10)
 
 ## NEW FEATURES


### PR DESCRIPTION
## Purpose

Prepare the 1.0.0 release of CroPlotR.

This release mainly corresponds to a major refactoring aimed at improving code structure, maintainability, and documentation, without changing the public API.

## Changes

- Bump version to 1.0.0 in `DESCRIPTION`
- Update `NEWS.md`
- Update `CITATION.cff`

## Notes

- No functional changes are introduced in this PR
- This PR only finalizes the release metadata and documentation
- Code changes have already been merged in previous PRs

## Checklist

- [x] Version number updated
- [x] NEWS.md updated
- [x] CITATION.cff updated
- [x] Ready to tag `v1.0.0` after merge