### PR TITLE
Update cropr_formatting.R

### DIFF
--- a/R/cropr_formatting.R
+++ b/R/cropr_formatting.R
@@ -216,7 +216,8 @@ format_cropr <- function(sim, obs = NULL, obs_sd = NULL,
         obs[which(is.na(obs[, to_replace[1]])), to_replace[1]] <-
           obs[which(is.na(obs[, to_replace[1]])), to_replace[2], drop = TRUE]
         if (is_obs_sd) {
-          obs_sd[which(is.na(obs_sd[, to_replace[1]])),
+          obs_sd[
+            which(is.na(obs_sd[, to_replace[1]])),
             to_replace[1]
           ] <-
             obs_sd[


### PR DESCRIPTION
remove `drop` argument on the LHS of `obs` / `obs_sd` when replacing duplicated columns. This is because the `drop` argument can only be used in the getter, not the setter (which is obvious).