### PR TITLE
Fix save_plot_png when plot is just a ggplot

### DIFF
--- a/R/save_plot_png.R
+++ b/R/save_plot_png.R
@@ -59,7 +59,8 @@ save_plot_png <- function(plot, out_dir, suffix = "", width = 17, height = 12,
     },
     error = function(cond) {
       if (grepl("Graphics API version mismatch", cond)) {
-        stop("Error in save_plot_png, may be due to the use of a too old version
+        stop(
+          "Error in save_plot_png, may be due to the use of a too old version
           of the R package ragg. Please try to update it.\n Original error
           message:",
           cond


### PR DESCRIPTION
This PR fixes this error when using save_plot_png() on a ggplot:

> Error in S7::prop(x, "meta")[[i]] : subscript out of bounds

The bug happens because the function was trying to handle a ggplot object as if it were a list of plots.

Adding return() ensures mutual exclusivity between the two cases

