### PR TITLE
use reusable workflow for sticsrtests

### DIFF
--- a/.github/workflows/check-standard.yaml
+++ b/.github/workflows/check-standard.yaml
@@ -2,8 +2,9 @@
 # Need help debugging build failures? Start at https://github.com/r-lib/actions#where-to-find-help
 on:
   push:
-    #branches: [main, master]
+    branches: [main, master]
   pull_request:
+    branches: [main, master]
 
 name: R-CMD-check
 
@@ -55,65 +56,3 @@ jobs:
       - uses: r-lib/actions/check-r-package@v2
         with:
           upload-snapshots: true
-
-  # Trigger CI using SticsRTest
-  trigger-SticsRTest:
-    name: Trigger SticsRTest check
-    # Triggering for every branch when checks succeeded
-    needs: R-CMD-check
-    if: github.event_name == 'push' && needs.R-CMD-check.result == 'success'
-    runs-on: ubuntu-latest
-    steps:
-      - name: Trigger
-        uses: peter-evans/repository-dispatch@v4
-        with:
-          token: ${{ secrets.TRIGGER_PAT }}
-          repository: SticsRPacks/SticsRTests
-          event-type: R-CMD-check
-          client-payload: '{"ref": "${{ github.ref }}", "sha": "${{ github.sha }}", "repo": "${{ github.event.repository.name }}"}'
-      - name: Wait for SticsRTests workflow to complete (block-and-fail)
-        uses: actions/github-script@v8
-        with:
-          github-token: ${{ secrets.TRIGGER_PAT }}
-          script: |
-            const owner = 'SticsRPacks';
-            const repo = 'SticsRTests';
-            // The dispatched sha from the source workflow
-            const headSha = process.env.GITHUB_SHA;
-            const maxWaitMs = 30 * 60 * 1000; // 30 minutes
-            const pollIntervalMs = 15 * 1000; // 15s
-            const start = Date.now();
-
-            function sleep(ms) {
-              return new Promise(resolve => setTimeout(resolve, ms));
-            }
-
-            while (Date.now() - start < maxWaitMs) {
-              const res = await github.rest.actions.listWorkflowRunsForRepo({ owner, repo, per_page: 100 });
-              const runs = (res.data.workflow_runs || []).filter(r => r.event === 'repository_dispatch');
-
-              // Prefer matching by head_sha, fallback to the most recent repository_dispatch run
-              let run = runs.find(r => r.head_sha === headSha) || runs.sort((a,b) => new Date(b.created_at) - new Date(a.created_at))[0];
-
-              if (!run) {
-                console.log('No repository_dispatch run found yet, sleeping...');
-                await sleep(pollIntervalMs);
-                continue;
-              }
-
-              console.log(`Found run id=${run.id} status=${run.status} conclusion=${run.conclusion} created_at=${run.created_at}`);
-
-              if (run.status === 'completed') {
-                if (run.conclusion === 'success') {
-                  console.log('SticsRTests workflow succeeded.');
-                  return { runId: run.id, conclusion: run.conclusion };
-                } else {
-                  throw new Error(`SticsRTests workflow completed with conclusion: ${run.conclusion}`);
-                }
-              }
-
-              // not completed yet
-              await sleep(pollIntervalMs);
-            }
-
-            throw new Error('Timed out waiting for SticsRTests workflow to start/complete (timeout reached).');

--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -14,32 +14,35 @@ on:
         required: false
         default: main
         type: string
+      dependency_mode:
+        description: Ref selection mode for the other SticsRPacks packages
+        required: false
+        default: release
+        type: choice
+        options:
+          - main
+          - release
 
 permissions:
   contents: read
 
 jobs:
   integration-tests:
-    name: branch + others ${{ matrix.dependency_mode }}
+    name: branch + others ${{ github.event_name == 'workflow_dispatch' && inputs.dependency_mode || 'release' }}
     if: >-
       github.event_name == 'workflow_dispatch' ||
       (
         github.event.workflow_run.conclusion == 'success' &&
         github.event.workflow_run.event == 'push' &&
         (
-          github.event.workflow_run.head_branch == 'main' ||
-          github.event.workflow_run.head_branch == 'master'
+          github.event.workflow_run.head_branch == 'main'
         )
       )
-    strategy:
-      fail-fast: false
-      matrix:
-        dependency_mode: [release]
     uses: SticsRPacks/SticsRTests/.github/workflows/integration-tests.yaml@main
     with:
       repo: CroPlotR
       ref: ${{ github.event_name == 'workflow_dispatch' && github.ref_name || github.event.workflow_run.head_branch }}
       sha: ${{ github.event_name == 'workflow_dispatch' && github.sha || github.event.workflow_run.head_sha }}
-      dependency_mode: ${{ matrix.dependency_mode }}
+      dependency_mode: ${{ github.event_name == 'workflow_dispatch' && inputs.dependency_mode || 'release' }}
       sticsrtests_ref: ${{ github.event_name == 'workflow_dispatch' && inputs.sticsrtests_ref || 'main' }}
     secrets: inherit

--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -1,0 +1,41 @@
+name: integration-tests
+
+on:
+  workflow_run:
+    workflows: ["R-CMD-check"]
+    types: [completed]
+  workflow_dispatch:
+    inputs:
+      sticsrtests_ref:
+        description: Branch, tag, or SHA of SticsRTests to run
+        required: false
+        default: main
+        type: string
+
+permissions:
+  contents: read
+
+jobs:
+  integration-tests:
+    name: branch + others ${{ matrix.dependency_mode }}
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      (
+        github.event.workflow_run.conclusion == 'success' &&
+        (
+          github.event.workflow_run.event == 'pull_request' ||
+          github.event.workflow_run.head_branch == 'main'
+        )
+      )
+    strategy:
+      fail-fast: false
+      matrix:
+        dependency_mode: [main, release]
+    uses: SticsRPacks/SticsRTests/.github/workflows/integration-tests.yaml@main
+    with:
+      repo: CroPlotR
+      ref: ${{ github.event_name == 'workflow_dispatch' && github.ref_name || github.event.workflow_run.head_branch }}
+      sha: ${{ github.event_name == 'workflow_dispatch' && github.sha || github.event.workflow_run.head_sha }}
+      dependency_mode: ${{ matrix.dependency_mode }}
+      sticsrtests_ref: ${{ github.event_name == 'workflow_dispatch' && inputs.sticsrtests_ref || 'main' }}
+    secrets: inherit

--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -1,4 +1,7 @@
 name: integration-tests
+run-name: >-
+  integration-tests for ${{ github.event_name == 'workflow_dispatch' && github.ref_name || github.event.workflow_run.head_branch }}
+  with SticsRTests@${{ github.event_name == 'workflow_dispatch' && inputs.sticsrtests_ref || 'main' }}
 
 on:
   workflow_run:
@@ -22,15 +25,16 @@ jobs:
       github.event_name == 'workflow_dispatch' ||
       (
         github.event.workflow_run.conclusion == 'success' &&
+        github.event.workflow_run.event == 'push' &&
         (
-          github.event.workflow_run.event == 'pull_request' ||
-          github.event.workflow_run.head_branch == 'main'
+          github.event.workflow_run.head_branch == 'main' ||
+          github.event.workflow_run.head_branch == 'master'
         )
       )
     strategy:
       fail-fast: false
       matrix:
-        dependency_mode: [main, release]
+        dependency_mode: [release]
     uses: SticsRPacks/SticsRTests/.github/workflows/integration-tests.yaml@main
     with:
       repo: CroPlotR

--- a/.github/workflows/pr-checks.yaml
+++ b/.github/workflows/pr-checks.yaml
@@ -1,10 +1,12 @@
-# Workflow derived from https://github.com/r-lib/actions/tree/v2/examples
-# Need help debugging build failures? Start at https://github.com/r-lib/actions#where-to-find-help
+name: pull-request-checks
+run-name: pull-request-checks for ${{ github.head_ref }}
+
 on:
-  push:
+  pull_request:
     branches: [main, master]
 
-name: R-CMD-check
+permissions:
+  contents: read
 
 jobs:
   R-CMD-check:
@@ -16,7 +18,6 @@ jobs:
       fail-fast: false
       matrix:
         config:
-          #- { os: macos-latest, r: "release" }
           - { os: windows-latest, r: "release" }
           - { os: windows-latest, r: "4.2.0" }
           - {
@@ -32,7 +33,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      - uses: r-hub/actions/setup-r-sysreqs@v1 # Install and setup R system dependencies on macOS.
+      - uses: r-hub/actions/setup-r-sysreqs@v1
         with:
           type: full
 
@@ -54,3 +55,27 @@ jobs:
       - uses: r-lib/actions/check-r-package@v2
         with:
           upload-snapshots: true
+
+  integration-tests-main:
+    name: integration-tests (others main)
+    needs: R-CMD-check
+    uses: SticsRPacks/SticsRTests/.github/workflows/integration-tests.yaml@main
+    with:
+      repo: CroPlotR
+      ref: ${{ github.head_ref }}
+      sha: ${{ github.event.pull_request.head.sha }}
+      dependency_mode: main
+      sticsrtests_ref: main
+    secrets: inherit
+
+  integration-tests-release:
+    name: integration-tests (others release)
+    needs: R-CMD-check
+    uses: SticsRPacks/SticsRTests/.github/workflows/integration-tests.yaml@main
+    with:
+      repo: CroPlotR
+      ref: ${{ github.head_ref }}
+      sha: ${{ github.event.pull_request.head.sha }}
+      dependency_mode: release
+      sticsrtests_ref: main
+    secrets: inherit


### PR DESCRIPTION
Instead of using a repository-dispatch, we now use a reusable workflow declared in SticsRTests, see:

https://github.com/SticsRPacks/SticsRTests/blob/main/.github/workflows/integration-tests.yaml