### PR TITLE
Fix: missing observations when successive plots contain situations with no observations

### DIFF
--- a/R/cat_situations.R
+++ b/R/cat_situations.R
@@ -149,8 +149,8 @@ cat_successive <-
         new_name <- ""
         col_obs <- c()
         new_obs <- data.frame()
-        for (sit in list_succ) {
-          if (length(intersect(names(obs), list_succ)) > 0) {
+        if (length(intersect(names(obs), list_succ)) > 0) {
+          for (sit in list_succ) {
             new_name <- paste0(new_name, sit, " | ")
             if (sit %in% names(obs)) {
               new_obs <- dplyr::bind_rows(new_obs, obs[[sit]])

--- a/R/cropr_formatting.R
+++ b/R/cropr_formatting.R
@@ -131,10 +131,6 @@ format_cropr <- function(sim, obs = NULL, obs_sd = NULL,
     melt_vars <- "Date"
   }
 
-  if (!is.null(successive)) {
-    melt_vars <- c(melt_vars, "succession_date")
-  }
-
   if ("sit_name" %in% colnames(sim)) {
     melt_vars <- c(melt_vars, "sit_name")
   }
@@ -149,6 +145,10 @@ format_cropr <- function(sim, obs = NULL, obs_sd = NULL,
     melt_vars_sim <- c(melt_vars, "version")
   } else {
     melt_vars_sim <- melt_vars
+  }
+  # and succession_date is only included in sim
+  if (!is.null(successive)) {
+    melt_vars_sim <- c(melt_vars_sim, "succession_date")
   }
 
   # Identify which columns are character vectors:
@@ -351,13 +351,13 @@ format_cropr <- function(sim, obs = NULL, obs_sd = NULL,
     obs <-
       obs %>%
       dplyr::select(-tidyselect::any_of(rem_vars)) %>%
-      reshape2::melt(id.vars = melt_vars, na.rm = TRUE, value.name = "Observed")
+      reshape2::melt(id.vars = melt_vars,na.rm = TRUE, value.name = "Observed")
 
     if (is_obs_sd) {
       obs_sd <-
         obs_sd %>%
         dplyr::select(-tidyselect::any_of(rem_vars)) %>%
-        reshape2::melt(id.vars = melt_vars, na.rm = TRUE, value.name = "Obs_SD")
+        reshape2::melt(id.vars = melt_vars,na.rm = TRUE, value.name = "Obs_SD")
     }
 
     if (select_dyn == "obs" || select_dyn == "common" || type == "scatter") {

--- a/R/cropr_formatting.R
+++ b/R/cropr_formatting.R
@@ -351,13 +351,13 @@ format_cropr <- function(sim, obs = NULL, obs_sd = NULL,
     obs <-
       obs %>%
       dplyr::select(-tidyselect::any_of(rem_vars)) %>%
-      reshape2::melt(id.vars = melt_vars,na.rm = TRUE, value.name = "Observed")
+      reshape2::melt(id.vars = melt_vars, na.rm = TRUE, value.name = "Observed")
 
     if (is_obs_sd) {
       obs_sd <-
         obs_sd %>%
         dplyr::select(-tidyselect::any_of(rem_vars)) %>%
-        reshape2::melt(id.vars = melt_vars,na.rm = TRUE, value.name = "Obs_SD")
+        reshape2::melt(id.vars = melt_vars, na.rm = TRUE, value.name = "Obs_SD")
     }
 
     if (select_dyn == "obs" || select_dyn == "common" || type == "scatter") {


### PR DESCRIPTION
### Problem
When using `successive = TRUE` in CroPlotR, plots could fail to display observations correctly if at least one situation in the succession had no observations. In such cases, available observations were not displayed.

### Solution
The issue was caused by an incorrect succession name in the observation data.frame. This has been corrected.

### Linked issues
Closes #166 